### PR TITLE
fix: use `instanceof` elytra item check for compatability with modded elytras

### DIFF
--- a/common/src/main/java/net/nimajnebec/autoelytra/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/net/nimajnebec/autoelytra/mixin/LocalPlayerMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ElytraItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.nimajnebec.autoelytra.config.Configuration;
@@ -50,13 +51,13 @@ public class LocalPlayerMixin extends AbstractClientPlayer {
             List<ItemStack> inventory = this.autoelytra$getCombinedInventory();
 
             // Return if elytra is already equipped
-            if (inventory.get(CHEST_SLOT).is(Items.ELYTRA)) return;
+            if (inventory.get(CHEST_SLOT).getItem() instanceof ElytraItem) return;
 
             // Find elytra in inventory
             for (int slot = 0; slot < inventory.size(); slot++) {
                 ItemStack stack = inventory.get(slot);
 
-                if (stack.is(Items.ELYTRA)) {
+                if (stack.getItem() instanceof ElytraItem) {
                     AutoEquipController.setPreviousChestItem(inventory.get(CHEST_SLOT));
                     this.autoelytra$swapSlots(CHEST_SLOT, slot);
                     return;
@@ -76,7 +77,7 @@ public class LocalPlayerMixin extends AbstractClientPlayer {
         List<ItemStack> inventory = this.autoelytra$getCombinedInventory();
 
         // Check if just stopped flying
-        if (AutoEquipController.hasPreviousChestItem() && !this.isFallFlying() && inventory.get(CHEST_SLOT).is(Items.ELYTRA)) {
+        if (AutoEquipController.hasPreviousChestItem() && !this.isFallFlying() && inventory.get(CHEST_SLOT).getItem() instanceof ElytraItem) {
 
             // Find previous chest item
             for (int slot = 0; slot < inventory.size(); slot++) {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
 
   "depends": {
     "fabricloader": ">=0.14.21",
-    "minecraft": "1.20.4",
+    "minecraft": "1.20.x",
     "fabric": "*"
   },
 


### PR DESCRIPTION
Using `.getItem() instanceof ElytraItem` instead of `.is(Items.ELYTRA)` allows the swapping to function with modded elytra items that extend the vanilla `ElytraItem` class.

I also changed the Minecraft version dependency for the Fabric side to `1.20.x` so that the mod can still be used with earlier 1.20 versions. I only tested that it's working on 1.20.2 and I didn't test Forge at all.